### PR TITLE
Add text UI for browsing emails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ description = "Import an mbox archive into sqlite"
 requires-python = ">=3.12"
 dependencies = [
     "tqdm",
+    "textual>=0.58",
 ]

--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,10 @@ python -m src.email_browser <database-file>
 
 Navigation uses the arrow keys (or `j`/`k`) to move through the message list.
 Press **Enter** to view the highlighted message. Inside the message view,
-press `a` to save attachments, `b` to go back and `q` to quit. Use `f` to
-apply a SQL filter and `s` to change the sort column.
+press `a` to save attachments, `b` to go back and `q` to quit.
+
+Use `f` to apply a SQL filter, for example `subject LIKE '%report%'`, and
+`s` to change the sort column (such as `received_at DESC`).
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -49,8 +49,9 @@ python -m src.email_browser <database-file>
 ```
 
 Navigation uses the arrow keys (or `j`/`k`) to move through the message list.
-Press **Enter** to view the highlighted message. Inside the message view,
-press `a` to save attachments, `b` to go back and `q` to quit.
+Press **Enter** to view the highlighted message. The list shows the sender for
+each email. Inside the message view, press `h` to toggle the header details,
+`a` to save attachments, `b` to go back and `q` to quit.
 
 Use `f` to apply a SQL filter, for example `subject LIKE '%report%'`, and
 `s` to change the sort column (such as `received_at DESC`).

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,21 @@ The importer creates a single table named `emails` containing:
 
 A view called `email_overview` exposes the `Date` header for convenience.
 
+## Browsing the database
+
+After importing, you can explore the stored emails using a
+Textual-powered interface reminiscent of classic mail clients:
+
+```bash
+python -m src.email_browser <database-file>
+```
+
+Navigation uses the arrow keys (or `j`/`k`) to move through the message list.
+Press **Enter** to view the highlighted message. Inside the message view,
+press `a` to save attachments, `b` to go back and `q` to quit. Use `f` to
+apply a SQL filter and `s` to change the sort column.
+
+
 ## License
 
 This project is distributed under the terms of the GNU General Public License

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -184,16 +184,19 @@ class MessageScreen(Screen):
         super().__init__()
         self.msg_id = msg_id
         self.data = data
-        self.log: TextLog | None = None
+        # Textual's Screen already exposes a ``log`` attribute for logging,
+        # so store the viewer widget under a different name to avoid
+        # clobbering that property.
+        self.text_view: TextLog | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
-        self.log = TextLog(highlight=False, markup=False)
-        yield self.log
+        self.text_view = TextLog(highlight=False, markup=False)
+        yield self.text_view
         yield Footer()
 
     def on_mount(self) -> None:
-        assert self.log is not None
+        assert self.text_view is not None
         lines: List[str] = []
         headers = self.data.get("headers", {})
         for k, values in headers.items():
@@ -202,7 +205,7 @@ class MessageScreen(Screen):
         lines.append("")
         self._payload_to_lines(self.data.get("payload"), lines)
         for line in lines:
-            self.log.write(line)
+            self.text_view.write(line)
 
     def action_save_attachments(self) -> None:
         self.app.save_attachments(self.msg_id)

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -28,6 +28,12 @@ class EmailBrowserApp(App):
     def __init__(self, db_path: Path) -> None:
         super().__init__()
         self.conn = sqlite3.connect(db_path)
+        # Some databases may contain invalid UTF-8 in the generated
+        # ``subject`` column which causes ``fetchmany`` to raise an
+        # ``OperationalError`` when Textual loads rows.  Using a
+        # ``text_factory`` that replaces undecodable characters prevents
+        # the crash while still showing the rest of the row.
+        self.conn.text_factory = lambda b: b.decode("utf-8", "replace")
         self.filter_clause = ""
         self.sort_clause = "received_at"
         self.table: DataTable | None = None

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -10,8 +10,16 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from textual.app import App, ComposeResult
-from textual.widgets import DataTable, Footer, Header, TextLog
+from textual.widgets import DataTable, Footer, Header
 from textual.screen import Screen
+
+# ``TextLog`` was renamed to ``Log`` in newer versions of Textual.  Import the
+# appropriate widget based on what is available so the browser works across a
+# range of Textual releases.
+try:  # pragma: no cover - import varies by Textual version
+    from textual.widgets import TextLog  # type: ignore
+except Exception:  # pragma: no cover - fallback for old/new versions
+    from textual.widgets import Log as TextLog
 
 
 class EmailBrowserApp(App):

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -23,6 +23,7 @@ class EmailBrowserApp(App):
         ("q", "quit", "Quit"),
         ("f", "filter", "Filter"),
         ("s", "sort", "Sort"),
+        ("enter", "view", "View"),
     ]
 
     def __init__(self, db_path: Path) -> None:
@@ -86,7 +87,8 @@ class EmailBrowserApp(App):
         row_key = self.table.cursor_row_key
         if row_key is None:
             return
-        msg_id = int(row_key)
+        key_value = row_key.value if hasattr(row_key, "value") else row_key
+        msg_id = int(key_value)
         data = self._load_message(msg_id)
         if not data:
             return
@@ -121,7 +123,8 @@ class EmailBrowserApp(App):
             self.call_later(self._load_next_batch)
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
-        msg_id = int(event.row_key)
+        key_value = event.row_key.value if hasattr(event.row_key, "value") else event.row_key
+        msg_id = int(key_value)
         data = self._load_message(msg_id)
         if data:
             self.push_screen(MessageScreen(self, msg_id, data))

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -1,0 +1,213 @@
+"""Textual-based browser for the email database."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+from textual.app import App, ComposeResult
+from textual.widgets import DataTable, Footer, Header, Input, TextLog
+from textual.screen import Screen
+
+
+class EmailBrowserApp(App):
+    """Interactive browser for exploring messages."""
+
+    CSS_PATH = None
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("enter", "view", "View message"),
+        ("f", "filter", "Filter"),
+        ("s", "sort", "Sort"),
+    ]
+
+    def __init__(self, db_path: Path) -> None:
+        super().__init__()
+        self.conn = sqlite3.connect(db_path)
+        self.filter_clause = ""
+        self.sort_clause = "received_at"
+        self.messages: Sequence[tuple] = []
+        self.table: DataTable | None = None
+
+    # ------------------------------------------------------------------
+    # Database helpers
+    # ------------------------------------------------------------------
+    def _query_messages(self) -> None:
+        query = "SELECT id, received_at, subject FROM emails"
+        if self.filter_clause:
+            query += f" WHERE {self.filter_clause}"
+        if self.sort_clause:
+            query += f" ORDER BY {self.sort_clause}"
+        query += " LIMIT 1000"
+        self.messages = self.conn.execute(query).fetchall()
+
+    def _get_message(self, msg_id: int) -> Dict[str, Any] | None:
+        row = self.conn.execute(
+            "SELECT as_json FROM emails WHERE id=?",
+            (msg_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return json.loads(row[0])
+
+    # ------------------------------------------------------------------
+    # Textual lifecycle
+    # ------------------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield Header()
+        self.table = DataTable(zebra_stripes=True)
+        self.table.cursor_type = "row"
+        self.table.focus()
+        yield self.table
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._query_messages()
+        assert self.table is not None
+        self.table.add_columns("ID", "Received", "Subject")
+        for row in self.messages:
+            self.table.add_row(str(row[0]), row[1], row[2])
+        self.table.focus()
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    def action_view(self) -> None:
+        assert self.table is not None
+        if not self.table.row_count:
+            return
+        row_idx = self.table.cursor_row
+        msg_id = int(self.table.get_row(row_idx)[0])
+        data = self._get_message(msg_id)
+        if not data:
+            return
+        self.push_screen(MessageScreen(self, msg_id, data))
+
+    async def action_filter(self) -> None:
+        clause = await self.ask("Filter SQL:")
+        if clause is not None:
+            self.filter_clause = clause
+            self.refresh_table()
+
+    async def action_sort(self) -> None:
+        column = await self.ask("Sort column:")
+        if column is not None:
+            self.sort_clause = column
+            self.refresh_table()
+
+    def refresh_table(self) -> None:
+        assert self.table is not None
+        self._query_messages()
+        self.table.clear()
+        for row in self.messages:
+            self.table.add_row(str(row[0]), row[1], row[2])
+        if self.table.row_count:
+            self.table.cursor_coordinate = (0, 0)
+
+    # ------------------------------------------------------------------
+    # Attachment helpers
+    # ------------------------------------------------------------------
+    def save_attachments(self, msg_id: int) -> None:
+        path_str = self.console.input("Save to directory: ")
+        if not path_str:
+            return
+        out_dir = Path(path_str)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        data = self._get_message(msg_id)
+        if not data:
+            return
+        attachments = self._collect_attachments(data.get("payload"))
+        for idx, att in enumerate(attachments, 1):
+            filename = att.get("filename") or f"attachment_{idx}"
+            with open(out_dir / filename, "wb") as fp:
+                fp.write(base64.b64decode(att.get("data_b64", "")))
+        self.console.print(f"Saved {len(attachments)} attachments to {out_dir}")
+
+    def _collect_attachments(self, payload: Any) -> List[Dict[str, Any]]:
+        attachments: List[Dict[str, Any]] = []
+        if isinstance(payload, list):
+            for part in payload:
+                attachments.extend(self._collect_attachments(part))
+        elif isinstance(payload, dict):
+            if payload.get("type") == "binary":
+                headers = payload.get("headers", {})
+                disp = headers.get("Content-Disposition", [""])[0]
+                filename = None
+                if "filename=" in disp:
+                    filename = disp.split("filename=")[-1].strip().strip('"')
+                attachments.append(
+                    {
+                        "data_b64": payload.get("data_b64", ""),
+                        "content_type": payload.get("content_type", ""),
+                        "filename": filename,
+                    }
+                )
+            else:
+                attachments.extend(self._collect_attachments(payload.get("payload")))
+        return attachments
+
+
+class MessageScreen(Screen):
+    """Screen for viewing a single message."""
+
+    BINDINGS = [
+        ("b", "app.pop_screen", "Back"),
+        ("a", "save_attachments", "Save attachments"),
+    ]
+
+    def __init__(self, app: EmailBrowserApp, msg_id: int, data: Dict[str, Any]) -> None:
+        super().__init__()
+        self.app = app
+        self.msg_id = msg_id
+        self.data = data
+        self.log: TextLog | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        self.log = TextLog(highlight=False, markup=False)
+        yield self.log
+        yield Footer()
+
+    def on_mount(self) -> None:
+        assert self.log is not None
+        lines: List[str] = []
+        headers = self.data.get("headers", {})
+        for k, values in headers.items():
+            if values:
+                lines.append(f"{k}: {values[0]}")
+        lines.append("")
+        self._payload_to_lines(self.data.get("payload"), lines)
+        for line in lines:
+            self.log.write(line)
+
+    def action_save_attachments(self) -> None:
+        self.app.save_attachments(self.msg_id)
+
+    def _payload_to_lines(self, payload: Any, lines: List[str], indent: int = 0) -> None:
+        if isinstance(payload, list):
+            for part in payload:
+                self._payload_to_lines(part, lines, indent)
+        elif isinstance(payload, dict):
+            if payload.get("type") == "text":
+                text = payload.get("text", "")
+                for line in text.splitlines():
+                    lines.append(" " * indent + line)
+            else:
+                lines.append(" " * indent + f"[binary data {payload.get('content_type')}]")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Browse email database")
+    parser.add_argument("sqlite_db", type=Path, help="Path to SQLite database")
+    args = parser.parse_args()
+    EmailBrowserApp(args.sqlite_db).run()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 from textual.app import App, ComposeResult
-from textual.widgets import DataTable, Footer, Header, Input, TextLog
+from textual.widgets import DataTable, Footer, Header, TextLog
 from textual.screen import Screen
 
 

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -92,7 +92,7 @@ class EmailBrowserApp(App):
         data = self._load_message(msg_id)
         if not data:
             return
-        self.push_screen(MessageScreen(self, msg_id, data))
+        self.push_screen(MessageScreen(msg_id, data))
 
     async def action_filter(self) -> None:
         clause = await self.ask("Filter SQL:")
@@ -127,7 +127,7 @@ class EmailBrowserApp(App):
         msg_id = int(key_value)
         data = self._load_message(msg_id)
         if data:
-            self.push_screen(MessageScreen(self, msg_id, data))
+            self.push_screen(MessageScreen(msg_id, data))
 
     # ------------------------------------------------------------------
     # Attachment helpers
@@ -180,9 +180,8 @@ class MessageScreen(Screen):
         ("a", "save_attachments", "Save attachments"),
     ]
 
-    def __init__(self, app: EmailBrowserApp, msg_id: int, data: Dict[str, Any]) -> None:
+    def __init__(self, msg_id: int, data: Dict[str, Any]) -> None:
         super().__init__()
-        self.app = app
         self.msg_id = msg_id
         self.data = data
         self.log: TextLog | None = None

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -46,7 +46,7 @@ class EmailBrowserApp(App):
         query += " LIMIT 1000"
         self.messages = self.conn.execute(query).fetchall()
 
-    def _get_message(self, msg_id: int) -> Dict[str, Any] | None:
+    def _load_message(self, msg_id: int) -> Dict[str, Any] | None:
         row = self.conn.execute(
             "SELECT as_json FROM emails WHERE id=?",
             (msg_id,),
@@ -83,7 +83,7 @@ class EmailBrowserApp(App):
             return
         row_idx = self.table.cursor_row
         msg_id = int(self.table.get_row(row_idx)[0])
-        data = self._get_message(msg_id)
+        data = self._load_message(msg_id)
         if not data:
             return
         self.push_screen(MessageScreen(self, msg_id, data))
@@ -118,7 +118,7 @@ class EmailBrowserApp(App):
             return
         out_dir = Path(path_str)
         out_dir.mkdir(parents=True, exist_ok=True)
-        data = self._get_message(msg_id)
+        data = self._load_message(msg_id)
         if not data:
             return
         attachments = self._collect_attachments(data.get("payload"))

--- a/src/email_browser.py
+++ b/src/email_browser.py
@@ -8,6 +8,7 @@ import json
 import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List
+import inspect
 
 from textual.app import App, ComposeResult
 from textual.widgets import DataTable, Footer, Header
@@ -20,6 +21,17 @@ try:  # pragma: no cover - import varies by Textual version
     from textual.widgets import TextLog  # type: ignore
 except Exception:  # pragma: no cover - fallback for old/new versions
     from textual.widgets import Log as TextLog
+
+
+def _create_text_log() -> TextLog:
+    """Create a TextLog/Log widget while handling version differences."""
+    params = inspect.signature(TextLog).parameters
+    kwargs: dict[str, Any] = {}
+    if "highlight" in params:
+        kwargs["highlight"] = False
+    if "markup" in params:
+        kwargs["markup"] = False
+    return TextLog(**kwargs)
 
 
 class EmailBrowserApp(App):
@@ -199,7 +211,7 @@ class MessageScreen(Screen):
 
     def compose(self) -> ComposeResult:
         yield Header()
-        self.text_view = TextLog(highlight=False, markup=False)
+        self.text_view = _create_text_log()
         yield self.text_view
         yield Footer()
 


### PR DESCRIPTION
## Summary
- add an interactive Textual browser for SQLite email database
- document controls in README
- depend on Textual

## Testing
- `python -m py_compile src/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68569a1a9efc83338df70e8316896ef0